### PR TITLE
Fix dockerfile still looking for bot.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --without=dev
 
 COPY . /app/
-ENTRYPOINT poetry run python -O bot.py
+ENTRYPOINT poetry run python -O launcher.py


### PR DESCRIPTION
During the last clean sweep I missed that the Dockerfile still looks for `bot.py` (pre launcher rework). This amends that.