### PR TITLE
Add ownership control of the bot via a config key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --without=dev
 
 COPY . /app/
-ENTRYPOINT poetry run python -O bot.py
+ENTRYPOINT poetry run python -O launcher.py

--- a/config.template.toml
+++ b/config.template.toml
@@ -1,4 +1,6 @@
 prefix = '>>'
+owner_ids = [123, 456, 789] # user or role ids, optional
+
 [TOKENS]
 bot = ''
 idevision = ''

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -22,4 +22,5 @@ SOFTWARE.
 """
 from .constants import *
 
+
 GUILD_ID: int = 490948346773635102

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -22,6 +22,7 @@ SOFTWARE.
 """
 from ._meta import CONSTANTS
 
+
 __all__ = (
     "Roles",
     "Colours",

--- a/core/utils/formatters.py
+++ b/core/utils/formatters.py
@@ -22,6 +22,7 @@ SOFTWARE.
 """
 from discord.utils import escape_markdown
 
+
 __all__ = ("to_codeblock",)
 
 

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,6 +1,7 @@
 import pathlib
 from pkgutil import ModuleInfo, iter_modules
 
+
 _ext: list[ModuleInfo] = []
 _ext.extend(
     [
@@ -15,9 +16,7 @@ if private_path.exists():
     _ext.extend(
         [
             module
-            for module in iter_modules(
-                [str(private_path.absolute())], prefix=__package__ + ".private."
-            )
+            for module in iter_modules([str(private_path.absolute())], prefix=__package__ + ".private.")
             if not module.name.rsplit(".")[-1].startswith("_")
         ]
     )

--- a/modules/admin.py
+++ b/modules/admin.py
@@ -20,8 +20,53 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+import logging
+
+from discord.ext import commands
+
 import core
+from constants import GUILD_ID
+from core.context import Context
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Administration(commands.Cog):
+    def __init__(self, bot: core.Bot, /) -> None:
+        self.bot: core.Bot = bot
+        if owners := core.CONFIG.get("owner_ids"):
+            LOGGER.info("[Ownership] Setting new owners to:\n%s", ", ".join([str(o) for o in owners]))
+            bot.loop.create_task(self.populate_owners(owners))
+
+    async def cog_check(self, ctx: Context) -> bool:  # type: ignore  # maybecoro override woes
+        return await self.bot.is_owner(ctx.author)
+
+    async def populate_owners(self, owner_ids: list[int]) -> None:
+        await self.bot.wait_until_ready()
+
+        new_owners: list[int] = []
+        for id_ in owner_ids:
+            user = self.bot.get_user(id_)
+            if user:
+                LOGGER.info("[Ownership] New User found for owner: %s (%s)", str(user), user.id)
+                new_owners.append(id_)
+                continue
+
+            guild = self.bot.get_guild(GUILD_ID)
+            if not guild:
+                continue
+
+            role = guild.get_role(id_)
+            if role:
+                LOGGER.info("[Ownership] New Role found for owner: %s (%s)", str(role), role.id)
+                new_owners += [m.id for m in role.members]
+                continue
+
+        if new_owners:
+            self.bot.owner_id = None
+            self.bot.owner_ids = set(new_owners)
 
 
 async def setup(bot: core.Bot) -> None:
-    pass
+    await bot.add_cog(Administration(bot))

--- a/modules/github.py
+++ b/modules/github.py
@@ -46,18 +46,16 @@ LIB_REPO_MAPPING = {key: value for keys, value in aliases for key in keys}
 
 
 class GitHub(core.Cog):
-
     def __init__(self, bot: core.Bot) -> None:
         self.bot = bot
         self.code_highlight_emoji = "📃"
         self.highlight_timeout = 10
 
     def _strip_content_path(self, url: str) -> str:
-        file_path = url[len(GITHUB_BASE_URL):]
+        file_path = url[len(GITHUB_BASE_URL) :]
         return file_path
 
     async def format_highlight_block(self, url: str, line_adjustment: int = 10) -> dict[str, str | int] | None:
-
         try:
             highlighted_line = int(url.split("#L")[1])  # separate the #L{n} highlight
         except IndexError:
@@ -106,7 +104,7 @@ class GitHub(core.Cog):
 
             else:
                 # if we hit the end of the file, just write an empty string
-                display_str = ("{}  {}\n" if line_list.get(key) is not None else "")
+                display_str = "{}  {}\n" if line_list.get(key) is not None else ""
                 msg += display_str.format(curr_line_no, line_list.get(key))
 
             key += 1
@@ -149,9 +147,7 @@ class GitHub(core.Cog):
 
         def check(reaction: discord.Reaction, user: discord.User) -> bool:
             return (
-                reaction.emoji == self.code_highlight_emoji and
-                user != self.bot.user and
-                message.id == reaction.message.id
+                reaction.emoji == self.code_highlight_emoji and user != self.bot.user and message.id == reaction.message.id
             )
 
         try:

--- a/types_/config.py
+++ b/types_/config.py
@@ -26,6 +26,7 @@ class Snekbox(TypedDict):
 
 class Config(TypedDict):
     prefix: str
+    owner_ids: NotRequired[list[int]]
     TOKENS: Tokens
     DATABASE: Database
     LOGGING: Logging


### PR DESCRIPTION
Adds an optional config key to the `config.toml` which controls owners.

During startup, after the bot is ready, it will attempt to resolve the Users and Roles in this config key and then set `Bot.owner_ids` to them, bypassing the api call to check the application owner.

I also ran black and isort across the codebase.