### PR TITLE
Autodeployment via GH Actions on commit to `main`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+jobs:
+  deploy:
+    name: Deploy bot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remote deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd ~/projects/pythonista-bot/
+            git stash || true
+            git pull --force || true
+            docker compose up --build -d
+          username: ${{ secrets.SSH_USER }}
+
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main


### PR DESCRIPTION
This PR adds the workflow that will rebuild the Bot on successful PR to `main` providing the local config file matches what it expects (which may still require manual intervention).

I have also added all of the necessary secrets to the repo.