### PR TITLE
Initial Pythonista API Websocket implementation.

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -5,6 +5,7 @@ owner_ids = [123, 456, 789] # user or role ids, optional
 bot = ''
 idevision = ''
 mystbin = ''
+pythonista = ''
 
 [DATABASE]
 dsn = 'postgres://pythonistabot:pythonistabot@database:5432/pythonistabot' # assumed default

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -31,7 +31,7 @@ __all__ = (
     "PAPIWebsocketSubscriptions",
     "PAPIWebsocketCloseCodes",
     "PAPIWebsocketNotificationTypes",
-    "PAPIWebsocketOPCodes"
+    "PAPIWebsocketOPCodes",
 )
 
 
@@ -89,18 +89,18 @@ class PAPIWebsocketOPCodes(CONSTANTS):
     NOTIFICATION: int = 2
 
     # Sent to Pythonista API...
-    SUBSCRIBE: str = 'subscribe'
-    UNSUBSCRIBE: str = 'unsubscribe'
+    SUBSCRIBE: str = "subscribe"
+    UNSUBSCRIBE: str = "unsubscribe"
 
 
 class PAPIWebsocketSubscriptions(CONSTANTS):
-    DPY_MOD_LOG: str = 'discord_py_mod_log'
+    DPY_MOD_LOG: str = "discord_py_mod_log"
 
 
 class PAPIWebsocketNotificationTypes(CONSTANTS):
     # Subscriptions...
-    SUBSCRIPTION_ADDED: str = 'subscription_added'
-    SUBSCRIPTION_REMOVED: str = 'subscription_removed'
+    SUBSCRIPTION_ADDED: str = "subscription_added"
+    SUBSCRIPTION_REMOVED: str = "subscription_removed"
 
     # Failures...
-    UNKNOWN_OP: str = 'unknown_op'
+    UNKNOWN_OP: str = "unknown_op"

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -94,7 +94,7 @@ class PAPIWebsocketOPCodes(CONSTANTS):
 
 
 class PAPIWebsocketSubscriptions(CONSTANTS):
-    DPY_MOD_LOG: str = "discord_py_mod_log"
+    DPY_MODLOG: str = "dpy_modlog"
 
 
 class PAPIWebsocketNotificationTypes(CONSTANTS):

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -23,7 +23,16 @@ SOFTWARE.
 from ._meta import CONSTANTS
 
 
-__all__ = ("Roles", "Colours", "Channels", "ForumTags")
+__all__ = (
+    "Roles",
+    "Colours",
+    "Channels",
+    "ForumTags",
+    "PAPIWebsocketSubscriptions",
+    "PAPIWebsocketCloseCodes",
+    "PAPIWebsocketNotificationTypes",
+    "PAPIWebsocketOPCodes"
+)
 
 
 class Roles(CONSTANTS):
@@ -66,3 +75,32 @@ class ForumTags(CONSTANTS):
     DISCORDPY = 1006716972802789457
     OTHER = 1006717008613740596
     RESOLVED = 1006769269201195059
+
+
+class PAPIWebsocketCloseCodes(CONSTANTS):
+    NORMAL: int = 1000
+    ABNORMAL: int = 1006
+
+
+class PAPIWebsocketOPCodes(CONSTANTS):
+    # Received from Pythonista API...
+    HELLO: int = 0
+    EVENT: int = 1
+    NOTIFICATION: int = 2
+
+    # Sent to Pythonista API...
+    SUBSCRIBE: str = 'subscribe'
+    UNSUBSCRIBE: str = 'unsubscribe'
+
+
+class PAPIWebsocketSubscriptions(CONSTANTS):
+    DPY_MOD_LOG: str = 'discord_py_mod_log'
+
+
+class PAPIWebsocketNotificationTypes(CONSTANTS):
+    # Subscriptions...
+    SUBSCRIPTION_ADDED: str = 'subscription_added'
+    SUBSCRIPTION_REMOVED: str = 'subscription_removed'
+
+    # Failures...
+    UNKNOWN_OP: str = 'unknown_op'

--- a/modules/api.py
+++ b/modules/api.py
@@ -48,13 +48,21 @@ class API(core.Cog):
     def __init__(self, bot: core.Bot) -> None:
         self.bot = bot
 
+        self.session: aiohttp.ClientSession | None = None
         self.backoff: ExponentialBackoff = ExponentialBackoff()  # type: ignore
         self.websocket: aiohttp.ClientWebSocketResponse | None = None
 
         self.connection_task: asyncio.Task[None] | None = None
         self.keep_alive_task: asyncio.Task[None] | None = None
 
+    @property
+    def headers(self) -> dict[str, Any]:
+        return {
+            'Authorization': core.CONFIG['TOKENS']['pythonista']
+        }
+
     async def cog_load(self) -> None:
+        self.session = aiohttp.ClientSession(headers=self.headers)
         self.connection_task = asyncio.create_task(self.connect())
 
     async def cog_unload(self) -> None:
@@ -74,6 +82,10 @@ class API(core.Cog):
             except Exception as e:
                 LOGGER.debug(f'Unable to cancel Pythonista API keep_alive_task in "cog_unload": {e}')
 
+    def dispatch(self, *, data: dict[str, Any]) -> None:
+        subscription: str = data["subscription"]
+        self.bot.dispatch(f"papi_{subscription}", data)
+
     def is_connected(self) -> bool:
         return self.websocket is not None and not self.websocket.closed
 
@@ -90,27 +102,23 @@ class API(core.Cog):
             except Exception as e:
                 LOGGER.debug(f"Failed to cancel Pythonista API Websocket keep alive. This is likely not a problem: {e}")
 
-        headers: dict[str, str] = {"Authorization": token}
-
         while True:
-            async with aiohttp.ClientSession(headers=headers) as session:
-                try:
-                    self.websocket = await session.ws_connect(url=WS_URL)  # type: ignore
-                except Exception as e:
-                    if isinstance(e, aiohttp.WSServerHandshakeError) and e.status == 403:
-                        LOGGER.critical("Unable to connect to Pythonista API Websocket, due to an incorrect token.")
-                        return
-                    else:
-                        LOGGER.debug(f"Unable to connect to Pythonista API Websocket: {e}.")
-
-                if self.is_connected():
-                    session.detach()
-                    break
+            try:
+                self.websocket = await self.session.ws_connect(url=WS_URL)  # type: ignore
+            except Exception as e:
+                if isinstance(e, aiohttp.WSServerHandshakeError) and e.status == 403:
+                    LOGGER.critical("Unable to connect to Pythonista API Websocket, due to an incorrect token.")
+                    return
                 else:
-                    delay: float = self.backoff.delay()  # type: ignore
-                    LOGGER.debug(f'Retrying Pythonista API Websocket connection in "{delay}" seconds.')
+                    LOGGER.debug(f"Unable to connect to Pythonista API Websocket: {e}.")
 
-                    await asyncio.sleep(delay)
+            if self.is_connected():
+                break
+            else:
+                delay: float = self.backoff.delay()  # type: ignore
+                LOGGER.debug(f'Retrying Pythonista API Websocket connection in "{delay}" seconds.')
+
+                await asyncio.sleep(delay)
 
         self.connection_task = None
         self.keep_alive_task = asyncio.create_task(self.keep_alive())
@@ -120,7 +128,7 @@ class API(core.Cog):
 
         initial: dict[str, Any] = {
             "op": PAPIWebsocketOPCodes.SUBSCRIBE,
-            "subscriptions": [PAPIWebsocketSubscriptions.DPY_MOD_LOG],
+            "subscriptions": [PAPIWebsocketSubscriptions.DPY_MODLOG],
         }
         await self.websocket.send_json(data=initial)
 
@@ -133,7 +141,7 @@ class API(core.Cog):
                 aiohttp.WSMsgType.CLOSE,
             )
             if message.type in closing:  # pyright: ignore[reportUnknownMemberType]
-                LOGGER.debug(f"Received a CLOSING/CLOSED/CLOSE message type from Pythonista API.")
+                LOGGER.debug("Received a CLOSING/CLOSED/CLOSE message type from Pythonista API.")
 
                 self.connection_task = asyncio.create_task(self.connect())
                 return
@@ -142,13 +150,10 @@ class API(core.Cog):
             op: int | None = data.get("op")
 
             if op == PAPIWebsocketOPCodes.HELLO:
-                LOGGER.info(f'Received HELLO from Pythonista API: `user={data["user_id"]}`')
+                LOGGER.info(f'Received HELLO from Pythonista API: user={data["user_id"]}')
 
             elif op == PAPIWebsocketOPCodes.EVENT:
-                subscription: str = data["subscription"]
-
-                if subscription == PAPIWebsocketSubscriptions.DPY_MOD_LOG:
-                    self.bot.dispatch("papi_dpy_modlog", data["payload"])
+                self.dispatch(data=data)
 
             elif op == PAPIWebsocketOPCodes.NOTIFICATION:
                 type_: str = data["type"]

--- a/modules/api.py
+++ b/modules/api.py
@@ -1,0 +1,171 @@
+"""MIT License
+
+Copyright (c) 2021-Present PythonistaGuild
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+from discord.backoff import ExponentialBackoff
+
+import core
+from constants import (
+    PAPIWebsocketOPCodes,
+    PAPIWebsocketCloseCodes,
+    PAPIWebsocketNotificationTypes,
+    PAPIWebsocketSubscriptions
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+WS_URL: str = 'wss://api.pythonista.gg/v1/websocket'
+
+
+class API(core.Cog):
+    def __init__(self, bot: core.Bot) -> None:
+        self.bot = bot
+
+        self.backoff: ExponentialBackoff = ExponentialBackoff()  # type: ignore
+        self.websocket: aiohttp.ClientWebSocketResponse | None = None
+
+        self.connection_task: asyncio.Task[None] | None = None
+        self.keep_alive_task: asyncio.Task[None] | None = None
+
+    async def cog_load(self) -> None:
+        self.connection_task = asyncio.create_task(self.connect())
+
+    async def cog_unload(self) -> None:
+        if self.connection_task:
+            try:
+                self.connection_task.cancel()
+            except Exception as e:
+                LOGGER.debug(f'Unable to cancel Pythonista API connection_task in "cog_unload": {e}')
+
+        if self.is_connected():
+            assert self.websocket
+            await self.websocket.close(code=PAPIWebsocketCloseCodes.NORMAL)
+
+        if self.keep_alive_task:
+            try:
+                self.keep_alive_task.cancel()
+            except Exception as e:
+                LOGGER.debug(f'Unable to cancel Pythonista API keep_alive_task in "cog_unload": {e}')
+
+    def is_connected(self) -> bool:
+        return self.websocket is not None and not self.websocket.closed
+
+    async def connect(self) -> None:
+        token: str | None = core.CONFIG['TOKENS'].get('pythonista')
+
+        if not token:
+            self.connection_task = None
+            return
+
+        if self.keep_alive_task:
+            try:
+                self.keep_alive_task.cancel()
+            except Exception as e:
+                LOGGER.debug(f'Failed to cancel Pythonista API Websocket keep alive. This is likely not a problem: {e}')
+
+        headers: dict[str, str] = {'Authorization': token}
+
+        while True:
+            async with aiohttp.ClientSession(headers=headers) as session:
+
+                try:
+                    self.websocket = await session.ws_connect(url=WS_URL)  # type: ignore
+                except Exception as e:
+                    if isinstance(e, aiohttp.WSServerHandshakeError) and e.status == 403:
+                        LOGGER.critical('Unable to connect to Pythonista API Websocket, due to an incorrect token.')
+                        return
+                    else:
+                        LOGGER.debug(f'Unable to connect to Pythonista API Websocket: {e}.')
+
+                if self.is_connected():
+                    session.detach()
+                    break
+                else:
+                    delay: float = self.backoff.delay()  # type: ignore
+                    LOGGER.debug(f'Retrying Pythonista API Websocket connection in "{delay}" seconds.')
+
+                    await asyncio.sleep(delay)
+
+        self.connection_task = None
+        self.keep_alive_task = asyncio.create_task(self.keep_alive())
+
+    async def keep_alive(self) -> None:
+        assert self.websocket
+
+        initial: dict[str, Any] = {
+            'op': PAPIWebsocketOPCodes.SUBSCRIBE,
+            'subscriptions': [PAPIWebsocketSubscriptions.DPY_MOD_LOG]
+        }
+        await self.websocket.send_json(data=initial)
+
+        while True:
+            message: aiohttp.WSMessage = await self.websocket.receive()
+
+            closing: tuple[aiohttp.WSMsgType, aiohttp.WSMsgType, aiohttp.WSMsgType] = (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSING,
+                aiohttp.WSMsgType.CLOSE
+            )
+            if message.type in closing:  # pyright: ignore[reportUnknownMemberType]
+                LOGGER.debug(f'Received a CLOSING/CLOSED/CLOSE message type from Pythonista API.')
+
+                self.connection_task = asyncio.create_task(self.connect())
+                return
+
+            data: dict[str, Any] = message.json()
+            op: int | None = data.get('op')
+
+            if op == PAPIWebsocketOPCodes.HELLO:
+                LOGGER.info(f'Received HELLO from Pythonista API: `user={data["user_id"]}`')
+
+            elif op == PAPIWebsocketOPCodes.EVENT:
+                subscription: str = data['subscription']
+
+                if subscription == PAPIWebsocketSubscriptions.DPY_MOD_LOG:
+                    self.bot.dispatch('papi_dpy_modlog', data['payload'])
+
+            elif op == PAPIWebsocketOPCodes.NOTIFICATION:
+                type_: str = data['type']
+
+                if type_ == PAPIWebsocketNotificationTypes.SUBSCRIPTION_ADDED:
+                    subscribed: str = ', '.join(data['subscriptions'])
+                    LOGGER.info(f'Pythonista API added our subscription, currently subscribed: `{subscribed}`')
+                elif type_ == PAPIWebsocketNotificationTypes.SUBSCRIPTION_REMOVED:
+                    subscribed: str = ', '.join(data['subscriptions'])
+                    LOGGER.info(f'Pythonista API removed our subscription, currently subscribed: `{subscribed}`')
+                elif type_ == PAPIWebsocketNotificationTypes.UNKNOWN_OP:
+                    LOGGER.info(f'We sent an UNKNOWN OP to Pythonista API: `{data["received"]}`')
+
+            else:
+                LOGGER.info('Received an UNKNOWN OP from Pythonista API.')
+
+
+async def setup(bot: core.Bot) -> None:
+    await bot.add_cog(API(bot))

--- a/modules/api.py
+++ b/modules/api.py
@@ -57,9 +57,7 @@ class API(core.Cog):
 
     @property
     def headers(self) -> dict[str, Any]:
-        return {
-            'Authorization': core.CONFIG['TOKENS']['pythonista']
-        }
+        return {"Authorization": core.CONFIG["TOKENS"]["pythonista"]}
 
     async def cog_load(self) -> None:
         self.session = aiohttp.ClientSession(headers=self.headers)

--- a/modules/api.py
+++ b/modules/api.py
@@ -31,9 +31,9 @@ from discord.backoff import ExponentialBackoff
 
 import core
 from constants import (
-    PAPIWebsocketOPCodes,
     PAPIWebsocketCloseCodes,
     PAPIWebsocketNotificationTypes,
+    PAPIWebsocketOPCodes,
     PAPIWebsocketSubscriptions,
 )
 

--- a/types_/config.py
+++ b/types_/config.py
@@ -9,6 +9,7 @@ class Tokens(TypedDict):
     idevision: str
     mystbin: str
     github_bot: str
+    pythonista: str
 
 
 class Database(TypedDict):


### PR DESCRIPTION
This adds a websocket listener for the Pythonista API.

To run this you must provide a Pythonista API Application token in the config that has websocket permissions.

Currently the only event this websocket subscribes to is `discord_py_mod_log`. When that event is received, a bot event via bot.dispatch is dispatched: `on_papi_dpy_modlog` which takes in one parameter, the payload data received from the API, without the op/user_id fields.

In the event that the Pythonista API is disconnected for some reason this will try to connect with an Expotential Backoff, unless the token is refused.

