### PR TITLE
update synced moderation reasons

### DIFF
--- a/modules/moderation.py
+++ b/modules/moderation.py
@@ -95,12 +95,34 @@ class ModerationRespostView(discord.ui.View):
         assert interaction.guild
         await interaction.response.defer(ephemeral=False)
 
-        reason = f"Banned due to grievances in discord.py: {self.target_reason!r}"
+        reason = (
+            f"Banned by {interaction.user} ({interaction.user.id}) due to grievances in discord.py: {self.target_reason!r}"
+        )
         await interaction.guild.ban(
             self.target,
             reason=shorten(reason, width=128, placeholder="..."),
         )
         await interaction.followup.send("Banned.")
+
+        self._disable_all_buttons()
+        await self.message.edit(view=self)
+
+    @discord.ui.button(label="Kick", emoji="\U0001f462")
+    async def kick_button(self, interaction: Interaction, button: discord.ui.Button[Self]) -> None:
+        assert interaction.guild
+        await interaction.response.defer(ephemeral=False)
+
+        reason = (
+            f"Kicked by {interaction.user} ({interaction.user.id}) due to grievances in discord.py: {self.target_reason!r}"
+        )
+        await interaction.guild.kick(
+            self.target,
+            reason=shorten(reason, width=128, placeholder="..."),
+        )
+        await interaction.followup.send("Banned.")
+
+        self._disable_all_buttons()
+        await self.message.edit(view=self)
 
 
 class Moderation(commands.Cog):

--- a/modules/moderation.py
+++ b/modules/moderation.py
@@ -115,7 +115,7 @@ class ModerationRespostView(discord.ui.View):
             self.target,
             reason=shorten(reason, width=128, placeholder="..."),
         )
-        await interaction.followup.send("Banned.")
+        await interaction.followup.send("Kicked.")
 
         self._disable_all_buttons()
         await self.message.edit(view=self)

--- a/modules/moderation.py
+++ b/modules/moderation.py
@@ -95,9 +95,7 @@ class ModerationRespostView(discord.ui.View):
         assert interaction.guild
         await interaction.response.defer(ephemeral=False)
 
-        reason = (
-            f"Banned by {interaction.user} ({interaction.user.id}) due to grievances in discord.py: {self.target_reason!r}"
-        )
+        reason = f"By {interaction.user} ({interaction.user.id}) due to grievances in discord.py: {self.target_reason!r}"
         await interaction.guild.ban(
             self.target,
             reason=shorten(reason, width=128, placeholder="..."),
@@ -112,9 +110,7 @@ class ModerationRespostView(discord.ui.View):
         assert interaction.guild
         await interaction.response.defer(ephemeral=False)
 
-        reason = (
-            f"Kicked by {interaction.user} ({interaction.user.id}) due to grievances in discord.py: {self.target_reason!r}"
-        )
+        reason = f"By {interaction.user} ({interaction.user.id}) due to grievances in discord.py: {self.target_reason!r}"
         await interaction.guild.kick(
             self.target,
             reason=shorten(reason, width=128, placeholder="..."),


### PR DESCRIPTION
This PR updates the audit log reason for synced moderation actions as to provide clarity on the moderator who clicked the button.
Also added a kick option for more minor offences.