### PR TITLE
Modernization: dependency versions and build image

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,5 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "charliermarsh.ruff",
-        "ms-python.black-formatter"
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 LABEL org.opencontainers.image.source=https://github.com/PythonistaGuild/Pythonista-Bot
 LABEL org.opencontainers.image.description="Pythonista Guild's Discord Bot"

--- a/poetry.lock
+++ b/poetry.lock
@@ -264,7 +264,7 @@ files = [
 
 [[package]]
 name = "discord.py"
-version = "2.4.0a4888+ge6a0dc5b"
+version = "2.4.0a4888+ge6a0dc5bc"
 description = "A Python wrapper for the Discord API"
 optional = false
 python-versions = ">=3.8.0"


### PR DESCRIPTION
## Description
This PR updates the runtime dependency versions for the bot and it's runtime needs.

We change the base docker image to use python3.12 for the performance increases there, albeit not much.

We remove the VSCode recommendation for the `black` extension too.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
